### PR TITLE
Prevent implicit rounding in ColorUtils

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,6 +29,9 @@ jobs:
           - php_version: 8.0
             phpunit_version: 8.*
             phptimer_version: 2.*
+          - php_version: 8.1
+            phpunit_version: 8.*
+            phptimer_version: 2.*
 
     name: PHP ${{ matrix.php_version }}
 

--- a/src/Canvas/ColorUtils.php
+++ b/src/Canvas/ColorUtils.php
@@ -208,15 +208,15 @@ class ColorUtils
         $backPA = $backA * (255 - $foreA);
         $pa = ($forePA + $backPA);
 
-        $b = (
+        $b = (int) (
             ($forePA * (($fore >> 8) & 0xff) + $backPA * (($back >> 8) & 0xff)) /
             $pa);
 
-        $g = (
+        $g = (int) (
             ($forePA * (($fore >> 16) & 0xff) + $backPA * (($back >> 16) & 0xff)) /
             $pa);
 
-        $r = (
+        $r = (int) (
             ($forePA * (($fore >> 24) & 0xff) + $backPA * (($back >> 24) & 0xff)) /
             $pa);
 


### PR DESCRIPTION
This PR fixes an exception occurring due to the implicit rounding when bit shifting the RGB values by explicitly casting them to integers before the final shifting happens.

[As of PHP 8.1 the implicit casting of floats to integers has been deprecated](https://wiki.php.net/rfc/implicit-float-int-deprecate).