### PR TITLE
Add/enable Dependabot to keep dependencies up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  # src: https://github.com/marketplace/actions/build-and-push-docker-images#keep-up-to-date-with-github-dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Also keep PHP (Composer) dependencies up-to-date
+  # see: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enabled update checking via Dependabot for
* GitHub Actions for updates or in case you are going to use that (just my default)
* PHP aka Composer

We successfully use it [for our Docker container](https://github.com/PrivateBin/docker-nginx-fpm-alpine/blob/master/.github/dependabot.yml) and [our main PrivateBin repo](https://github.com/PrivateBin/PrivateBin/pull/937). IMHO that has worked quite well, so IMHO, we can also use it here now.